### PR TITLE
fix: wrong repository directory and peerDeps

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -3,13 +3,14 @@
   "version": "1.0.3",
   "description": "Zero configuration to quickly create your application",
   "license": "MIT",
-  "homepage": "https://github.com/xun082/react-cli",
+  "homepage": "https://github.com/xun082/create-neat",
   "bugs": {
-    "url": "https://github.com/xun082/react-cli/issues"
+    "url": "https://github.com/xun082/create-neat/issues"
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/xun082/react-cli.git"
+    "url": "git+https://github.com/xun082/create-neat.git",
+    "directory": "packages/core"
   },
   "bin": {
     "create-neat": "./dist/index.js"
@@ -43,12 +44,10 @@
     "tar": "^6.1.15",
     "tslib": "^2.5.3"
   },
-  "peerDependencies": {
-    "typescript": ">=4.3.5"
-  },
   "devDependencies": {
     "@types/fs-extra": "^11.0.1",
     "@types/node": "^20.2.3",
-    "@types/tar": "^6.1.5"
+    "@types/tar": "^6.1.5",
+    "typescript": ">=4.3.5"
   }
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -47,7 +47,6 @@
   "devDependencies": {
     "@types/fs-extra": "^11.0.1",
     "@types/node": "^20.2.3",
-    "@types/tar": "^6.1.5",
-    "typescript": ">=4.3.5"
+    "@types/tar": "^6.1.5"
   }
 }


### PR DESCRIPTION
1. Incorrect URL, although it can be redirected, it can also be misleading
2. Wrong directory, you have two CLIs. When you run 'npm repo create-neat' and open your warehouse address, you should be directed to your CLI's directory
3. Are you sure you need TypeScript as peerDependencies? When the user does not have TypeScript, executing npm install create-neat will prompt the user to install TypeScript. Is this your expected performance？


