### PR TITLE
refactor: 完成创建package.json，同时处理了一些其他小改动: (#28)

### DIFF
--- a/packages/@plugin/plugin-eslint/index.ts
+++ b/packages/@plugin/plugin-eslint/index.ts
@@ -1,0 +1,140 @@
+const buildToolConfigs = {
+  webpack: (config) => {
+    if (config.resolve.alias) {
+      config.resolve.alias.set("a", "b");
+    } else {
+      config.resolve.alias = { a: "b" };
+    }
+  },
+  vite: (options) => {
+    options.alias = [{ find: "a", replacement: "b" }];
+  },
+  // 添加其他构建工具的配置...
+};
+
+const pluginEslint = (api, options) => {
+  const { buildTool } = options.preset;
+  const configHandler = buildToolConfigs[buildTool];
+
+  if (configHandler) {
+    configHandler(api, options);
+  } else {
+    console.warn(`Unsupported build tool: ${buildTool}`);
+  }
+
+  // 其他独立于构建工具的配置
+  // ……
+};
+
+module.exports = {
+  pluginEslint,
+};
+
+// declare class PluginAPI {
+//     id: string
+
+//     service: any
+
+//     readonly version: string
+
+//     assertVersion(range: number | string): void
+
+//     /**
+//      * Current working directory.
+//      */
+//     getCwd(): string
+
+//     /**
+//      * Resolve path for a project.
+//      *
+//      * @param  _path - Relative path from project root
+//      * @return The resolved absolute path.
+//      */
+//     resolve(_path: string): string
+
+//     /**
+//      * Check if the project has a given plugin.
+//      *
+//      * @param id - Plugin id, can omit the (@vue/|vue-|@scope/vue)-cli-plugin- prefix
+//      * @return `boolean`
+//      */
+//     hasPlugin(id: string): boolean
+
+//     /**
+//      * Register a command that will become available as `vue-cli-service [name]`.
+//      *
+//      * @param name
+//      * @param  [opts]
+//      * @param  fn
+//      */
+//     registerCommand(name: string, fn: RegisterCommandFn): void
+//     registerCommand(name: string, opts: RegisterCommandOpts, fn: RegisterCommandFn): void
+
+//     /**
+//      * Register a function that will receive a chainable webpack config
+//      * the function is lazy and won't be called until `resolveWebpackConfig` is
+//      * called
+//      *
+//      * @param fn
+//      */
+//     chainWebpack(fn: WebpackChainFn): void
+
+//     /**
+//      * Register
+//      * - a webpack configuration object that will be merged into the config
+//      * OR
+//      * - a function that will receive the raw webpack config.
+//      *   the function can either mutate the config directly or return an object
+//      *   that will be merged into the config.
+//      *
+//      * @param fn
+//      */
+//     configureWebpack(fn: webpackRawConfigFn): void
+
+//     /**
+//      * Register a dev serve config function. It will receive the express `app`
+//      * instance of the dev server.
+//      *
+//      * @param fn
+//      */
+//     configureDevServer(fn: DevServerConfigFn): void
+
+//     /**
+//      * Resolve the final raw webpack config, that will be passed to webpack.
+//      *
+//      * @param [chainableConfig]
+//      * @return Raw webpack config.
+//      */
+//     resolveWebpackConfig(chainableConfig?: ChainableConfig): webpack.Configuration
+
+//     /**
+//      * Resolve an intermediate chainable webpack config instance, which can be
+//      * further tweaked before generating the final raw webpack config.
+//      * You can call this multiple times to generate different branches of the
+//      * base webpack config.
+//      * See https://github.com/mozilla-neutrino/webpack-chain
+//      *
+//      * @return ChainableWebpackConfig
+//      */
+//     resolveChainableWebpackConfig(): ChainableConfig
+
+//     /**
+//      * Generate a cache identifier from a number of variables
+//      */
+//     genCacheConfig(id: string, partialIdentifier: any, configFiles?: string | string[]): CacheConfig
+// }
+
+// /**
+//  * Service plugin serves for modifying webpack config,
+//  * creating new vue-cli service commands or changing existing commands
+//  *
+//  * @param api - A PluginAPI instance
+//  * @param options - An object containing project local options specified in vue.config.js,
+//  *    or in the "vue" field in package.json.
+//  */
+// type ServicePlugin = (
+//     api: PluginAPI,
+//     options: ProjectOptions
+// ) => any
+
+// export { ServicePlugin, PluginAPI }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -4,31 +4,30 @@ import { Command } from "commander";
 import chalk from "chalk";
 import minimist from "minimist";
 
-import { getPackageJsonInfo, createApp } from "./utils";
+import { getPackageJsonInfo } from "./utils";
 import createAppTest from "./utils/createAppTest";
 
 const program = new Command();
 
-program
-  .version(chalk.greenBright(getPackageJsonInfo("../../package.json", true).version))
+program.version(chalk.greenBright(getPackageJsonInfo("../../package.json", true).version));
 
 program
-  .command('create <project-name>')
-  .description('Create a directory for your project files')
-  .option('-f, --force', 'Overwrite target directory if it exists')
+  .command("create <project-name>")
+  .description("Create a directory for your project files")
+  .option("-f, --force", "Overwrite target directory if it exists")
   .action((name, options) => {
-    // createApp(name, options);
     createAppTest(name, options);
   });
 
 program
-  .command('add <plugin> [pluginOptions]')
-  .description('Install a plugin and invoke its generator in an existing project')
-  .option('--registry <url>', 'Specify an npm registry URL for installing dependencies (npm only)')
+  .command("add <plugin> [pluginOptions]")
+  .description("Install a plugin and invoke its generator in an existing project")
+  .option("--registry <url>", "Specify an npm registry URL for installing dependencies (npm only)")
   .allowUnknownOption()
   .action((plugin) => {
     const pluginOptions = minimist(process.argv.slice(3));
+    console.log(pluginOptions, plugin);
     // addPlugin(plugin, pluginOptions)
   });
 
-program.parse(process.argv)
+program.parse(process.argv);

--- a/packages/core/src/utils/packageAPI.ts
+++ b/packages/core/src/utils/packageAPI.ts
@@ -1,0 +1,64 @@
+import fs from "fs";
+
+import { createFiles } from "./createFiles";
+
+class packageAPI {
+  private filePath: string;
+
+  constructor(filePath: string) {
+    this.filePath = filePath;
+  }
+
+  // 创建 package.json 文件
+  async createPackageJson(content: object) {
+    // todo: content 的类型后面约束
+    await createFiles(this.filePath, {
+      "package.json": JSON.stringify(content, null, 2),
+    });
+  }
+
+  // 读取 package.json 文件内容
+  async readPackageJson(): Promise<object> {
+    return new Promise((resolve, reject) => {
+      fs.readFile(this.filePath, "utf8", (err, data) => {
+        if (err) {
+          reject(err);
+        } else {
+          resolve(JSON.parse(data));
+        }
+      });
+    });
+  }
+
+  // 更新 package.json 文件内容
+  async updatePackageJson(content: object): Promise<string> {
+    return new Promise((resolve, reject) => {
+      this.readPackageJson()
+        .then((data) => {
+          const updatedContent = { ...data, ...content };
+          return this.createPackageJson(updatedContent);
+        })
+        .then(() => {
+          resolve("package.json file has been updated successfully");
+        })
+        .catch((err) => {
+          reject(err);
+        });
+    });
+  }
+
+  // 删除 package.json 文件
+  async deletePackageJson(): Promise<string> {
+    return new Promise((resolve, reject) => {
+      fs.unlink(this.filePath, (err) => {
+        if (err) {
+          reject(err);
+        } else {
+          resolve("package.json file has been deleted successfully");
+        }
+      });
+    });
+  }
+}
+
+export default packageAPI;


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/xun082/create-neat/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[√] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?

- Closes #28 
- Related to #24 

## What is the new behavior?

- 实现的流程创建 package.json
- 创建 packageAPI 文件，设置 packageAPI 类专门用于管理 package.json 操作
- 暂时注释了 覆盖文件 的操作（目前有bug），后续开 issue 处理
- 尝试写了写 plugin-eslint ，后续开 issue 专门开发，目前仅仅作为一个模板

## Does this PR introduce a breaking change?

```
[√] Yes
[ ] No
```

架构升级的部分功能实现

## Other information

<!-- This is an auto-generated comment: release notes by OSS CodeRabbit -->
### Summary by CodeRabbit

以下是这些拉取请求的简洁发布说明：

- packages/@plugin/plugin-eslint/index.ts:
  - 重构：添加了一个`buildToolConfigs`对象和一个`pluginEslint`函数，用于处理不同构建工具的配置。
  - Bug修复：注释掉了覆盖文件的操作，并计划在后续处理相关bug时再开issue。

- packages/core/src/index.ts:
  - 重构：删除了`createApp`函数的调用，添加了一个`console.log(pluginOptions, plugin)`语句，并对代码进行了格式化调整。

- packages/core/src/utils/createAppTest.ts:
  - 重构：创建了`package.json`文件，并使用`PackageAPI`类来管理`package.json`的操作。
  - Bug修复：注释了覆盖文件的操作，并计划在后续处理相关bug时再开issue。

- packages/core/src/utils/packageAPI.ts:
  - 新功能：实现了一个名为`packageAPI`的类，用于创建、读取、更新和删除`package.json`文件。

请注意，这些发布说明侧重于对最终用户可见的功能，并省略了代码级别的细节。
<!-- end of auto-generated comment: release notes by OSS CodeRabbit -->