### PR TITLE
ci: commit message不符合规范时抛出错误(#69)

### DIFF
--- a/scripts/check_commit_msg.sh
+++ b/scripts/check_commit_msg.sh
@@ -14,15 +14,23 @@ check_commit_message() {
     commit_msg="$1"
     # 检查提交信息是否以指定的前缀开头
     if ! echo "$commit_msg" | grep -qE "^(feat|fix|docs|style|refactor|test|chore|ci):"; then
+        echo -e "${RED}Inappropriate commit message:" "${NC}$1" >&2
         echo -e "${RED}Error:${NC} Commit message format is incorrect. It should start with one of '${BLUE}feat|fix|docs|style|refactor|test|chore|ci:${NC}'." >&2
         exit 1
     fi
 }
 
-# 遍历从start_sha到end_sha的所有提交
+# workflows传入两个参数，遍历从start_sha到end_sha的所有提交
+ if [ $# -eq 2 ]; then
 for sha in $(git rev-list $start_sha..$end_sha); do
     commit_msg=$(git show --format=%B -s $sha)
     check_commit_message "$commit_msg"
 done
+# huksy触发commit-msg钩子时传入一个参数
+elif [ $# -eq 1 ]; then
+   check_commit_message "$(cat $1) "
+else
+   echo -e "${RED} error: Failed to get commit message\n"
+fi
 
 echo -e "${BLUE}Commit message check passed.${NC}\n"


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/xun082/create-neat/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[✅] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?

- Closes #69 
- Related to #<!-- If this PR is related to other issues, please include their numbers. -->

## What is the new behavior?
commit时校验commit message，显示错误信息

<!-- Please describe the changes this PR makes and why it should be merged. Include any relevant issues it addresses. -->

## Does this PR introduce a breaking change?

```
[ ] Yes
[✅] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

<!-- This is an auto-generated comment: release notes by OSS CodeRabbit -->
### Summary by CodeRabbit

- Bug Fix: 添加了对提交信息格式的检查，以确保提交代码时的commit message符合规范。
- User Impact: 当提交的commit message格式不正确时，系统将抛出错误信息，提醒用户修改并重新提交。
- Refactor: 对`check_commit_message`函数进行了改动，添加了对提交信息格式的检查逻辑。
- Style: 优化了代码风格和可读性，使得代码更加清晰易懂。
- Documentation: 更新了相关文档，说明了正确的提交信息格式要求和错误信息的含义。
<!-- end of auto-generated comment: release notes by OSS CodeRabbit -->