### PR TITLE
feat: Changing the timing of initializing the project folder

### DIFF
--- a/packages/core/src/utils/createAppTest.ts
+++ b/packages/core/src/utils/createAppTest.ts
@@ -14,6 +14,9 @@ import createSuccessInfo from "./createSuccessInfo";
 import dependenciesInstall from "./dependenciesInstall";
 import { createReadmeString } from "./createFile";
 
+// Ctrl+C 退出时打印的提示信息
+const exitMsg: string = "⌨️  Ctrl+C pressed - Exiting the program";
+
 // 设置输入模式为原始模式
 process.stdin.setRawMode(true);
 
@@ -21,9 +24,17 @@ process.stdin.setRawMode(true);
 process.stdin.on("data", (key) => {
   // 检测到 Ctrl+C
   if (key[0] === 3) {
-    console.log("⌨️  Ctrl+C pressed - Exiting the program");
+    console.log(exitMsg);
     process.exit(1);
   }
+});
+
+// 这里的监听是为了：当用户输入完预设，此时项目文件夹已经创建并且在下载依赖，
+// 这时如果用户使用 Ctrl+C 终止了程序，那么清理掉初始化一半的文件夹
+process.on("SIGINT", () => {
+  console.log("\n" + exitMsg);
+  removeDirectory(rootDirectory, true);
+  process.exit(1);
 });
 
 // 创建项目文件夹
@@ -52,15 +63,18 @@ async function createFolder(rootDirectory: string, options: Record<string, any>)
   fs.mkdirSync(rootDirectory, { recursive: true });
 }
 
+// rootDirectory 由 create-neat 所在的系统根目录和用户输入的文件夹名称拼接而成
+let rootDirectory: string;
+
 // 模板创建主函数
 export default async function createAppTest(projectName: string, options: Record<string, any>) {
-  const rootDirectory = resolveApp(projectName);
-
-  await createFolder(rootDirectory, options);
+  rootDirectory = resolveApp(projectName);
 
   // 获取用户选择预设
   const preset: Preset = await projectSelect();
   const { packageManager } = preset;
+
+  await createFolder(rootDirectory, options);
 
   // 创建package.json
   console.log(chalk.blue(`\n📄  Generating package.json...`));


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/xun082/create-neat/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?

- Closes https://github.com/xun082/create-neat/issues/78
- Related to https://github.com/xun082/create-neat/issues/78

## What is the new behavior?

I changed the timing of initializing the project folder so that the project folder is only created when the user finishes typing the preset.

And also cleans up the project folder if dependency is being downloaded and the user types `CTRL+C` to terminate it.

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
