### PR TITLE
ci: 🎡 the pre commit hook monitors readme document changes and updates the core package document (#86)

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -5,5 +5,9 @@ echo 'running pre-commit checks ...'
 
 npx lint-staged -q
 
+echo 'running pre-commit workflow ...'
+
+node ./scripts/preCommitExec.mjs
+
 echo -e 'pre-commit success!\n'
 

--- a/scripts/preCommitExec.mjs
+++ b/scripts/preCommitExec.mjs
@@ -1,0 +1,51 @@
+import { resolve } from "node:path";
+import { execSync } from "node:child_process";
+
+main();
+
+function main() {
+  copyRootReadmeToTarget();
+}
+
+/**
+ * pre-commit hook to copy the root README.md to the target package.
+ */
+function copyRootReadmeToTarget() {
+  const rootReadmeMark = "README.md";
+
+  const rootReadmePath = resolve(process.cwd(), rootReadmeMark);
+  const targetFiles = ["packages/core/README.md"];
+  const cpFile = (targetPath) => {
+    if (hasFileChanged(rootReadmeMark)) {
+      execSync(`cp ${rootReadmePath} ${targetPath}`);
+      console.log(`Copied root README.md to ${targetPath}.`);
+    }
+  }
+
+  try {
+    mapFilesToPath(targetFiles).forEach(cpFile);
+  }
+  catch (error) {
+    console.error("Error executing git diff:", error);
+    process.exit(1);
+  }
+}
+
+/**
+ * transform the files array to the absolute path.
+ * @param files
+ * @returns {string[]}
+ */
+function mapFilesToPath(files) {
+  return files.map((file) => resolve(process.cwd(), file));
+}
+
+/**
+ * Check if the file has changed in the git diff.
+ * @param path {string} The path to the file to check.
+ * @returns {boolean}
+ */
+function hasFileChanged(path) {
+  const gitDiff = execSync("git diff --cached --name-only", { encoding: "utf-8" });
+  return gitDiff.split("\n").some((file) => file.trim() === path);
+}


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/xun082/create-neat/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[x] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?

- Closes #<!-- If this PR is related to other issues, please include their numbers. -->
- Related to #86<!-- If this PR is related to other issues, please include their numbers. -->

## What is the new behavior?

<!-- Please describe the changes this PR makes and why it should be merged. Include any relevant issues it addresses. -->
这次的提交pr主要做了在提交时，监听根目录文件夹下的readme文件变化，从而让package/core里面的readme进行同步更新。

目前做了可扩展方面的准备，以应对未来需要多个readme文档更新的情况。
因为是偏向于直接脚本执行的，所以没有用ts(省去npx ts-node编译了)使用了mjs书写代码，函数参数和返回会有注释说明。

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
针对当package/core/README.md修改后，后续没有加上这段代码。自己测试会发现有空的提交情况出现。后续再思考完善下。完全完善后会closes issue
```js
    execSync("git add .");
    execSync("git commit --no-verify --allow-empty-message");
```